### PR TITLE
fix: double the height of the NEW CHAT button

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -836,7 +836,7 @@ details[open] .suggested-header::before {
     border: none;
     outline: none;
     cursor: pointer;
-    padding: 0.75rem 1.25rem;
+    padding: 1.5rem 1.25rem;
     width: 100%;
     text-align: center;
     border-radius: 10px;


### PR DESCRIPTION
Doubled the vertical padding of .new-chat-btn from 0.75rem to 1.5rem, which doubles the button height. Items underneath shift down automatically due to normal document flow.

Closes #3

Generated with [Claude Code](https://claude.ai/code)